### PR TITLE
fix: add missing includes for gcc13

### DIFF
--- a/src/alphabet.h
+++ b/src/alphabet.h
@@ -20,8 +20,9 @@
 #ifndef ALPHABET_H
 #define ALPHABET_H
 
-#include "assert.h"
 #include <array>
+#include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <vector>
 

--- a/src/nucleotide.h
+++ b/src/nucleotide.h
@@ -20,6 +20,7 @@
 #define NUCLEOTIDE_H
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 // ============================================================================


### PR DESCRIPTION
- To be able to compile this with gcc13, it requires the explicit include `#include <cstdint>`.
- Changed `assert.h` to `cassert` (assert.h is C, cassert is C++, doesn't really matter)
