### PR TITLE
Use unordered_set to fix quadratic running time in FASTA parsing

### DIFF
--- a/src/buildindex.cpp
+++ b/src/buildindex.cpp
@@ -157,6 +157,9 @@ void concatenateAndTransform(const std::string& fastaFile,
     positions.reserve(expectedNumber + positions.size());
     seqNames.reserve(expectedNumber + seqNames.size());
 
+    // A hash table of sequence names for O(1) lookup
+    std::unordered_set<string> seqNamesLookup;
+
     firstSeqIDPerFile.push_back(seqNames.size());
 
     std::string sequence;
@@ -188,15 +191,16 @@ void concatenateAndTransform(const std::string& fastaFile,
             std::string name = description.substr(0, description.find(' '));
 
             // Check if the sequence name is already present
-            if (std::find(seqNames.begin(), seqNames.end(), name) !=
-                seqNames.end()) {
+            if (seqNamesLookup.count(name) > 0) {
                 throw std::runtime_error("Error: Sequence name " + name +
                                          " in file " + fastaFile +
                                          " is not unique!");
             }
 
             seqNames.emplace_back(name); // Store sequence name
+            seqNamesLookup.insert(name);
             sequenceName = true;
+
         } else {
             // Append to the current sequence
             sequence += line;


### PR DESCRIPTION
In FASTA parsing, sequence names were stored in a std::vector, and every new sequence name was searched versus every previous sequence name with std::find. This took O(n^2) time total, where n is the number of sequences, making the parsing extremely slow in my use case, where the index is a set of reads.

In this patch, I add an std::unordered_set of sequence names for O(1) sequence name lookup, reducing the running time to O(n).